### PR TITLE
refactor: replace indexing with iterators in save_stations

### DIFF
--- a/src/convert_file.rs
+++ b/src/convert_file.rs
@@ -5,8 +5,8 @@ use anyhow::{Context, Result};
 
 use crate::convert_pointcloud::{convert_pointcloud, convert_pointclouds};
 
-use crate::stations::save_stations;
 use crate::LasVersion;
+use crate::stations::save_stations;
 
 /// Converts a given e57 file into LAS format and, optionally, as stations.
 ///
@@ -66,7 +66,7 @@ pub fn convert_file(
             })
             .context("Error during the parallel processing of pointclouds")?;
 
-        save_stations(output_path, pointclouds)?;
+        save_stations(output_path, &pointclouds)?;
     } else {
         convert_pointclouds(e57_reader, &output_path, &las_version)
             .context("Error during the parallel processing of pointclouds")?;

--- a/src/stations.rs
+++ b/src/stations.rs
@@ -10,7 +10,10 @@ use std::{
     path::Path,
 };
 
-pub(crate) fn save_stations<P: AsRef<Path>>(output_path: P, pointclouds: &[PointCloud]) -> Result<()> {
+pub(crate) fn save_stations<P: AsRef<Path>>(
+    output_path: P,
+    pointclouds: &[PointCloud],
+) -> Result<()> {
     let stations: BTreeMap<usize, SpatialPoint> = pointclouds
         .iter()
         .enumerate()
@@ -27,7 +30,7 @@ pub(crate) fn save_stations<P: AsRef<Path>>(output_path: P, pointclouds: &[Point
         })
         .collect();
 
-    let stations_file = File::create(Path::new(&output_path).join("stations.json"))?;
+    let stations_file = File::create(output_path.as_ref().join("stations.json"))?;
     let mut writer = BufWriter::new(stations_file);
     serde_json::to_writer(&mut writer, &stations)?;
     writer.flush()?;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined how station data is built and written for clearer logic and modest efficiency gains.
  * Simplified input handling and import cleanup; output file and normal user workflows (stations.json generation) remain unchanged.
  * Developer-facing API adjusted to accept borrowed collections and more flexible path inputs (no impact on end-user behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->