### PR TITLE
fix: backfill missing point colors to avoid write crash on mixed-color data

### DIFF
--- a/src/convert_pointcloud.rs
+++ b/src/convert_pointcloud.rs
@@ -88,13 +88,23 @@ pub fn convert_pointcloud(
     )
     .context("Unable to create writer: ")?;
 
-    for p in las_points {
+    for mut p in las_points {
+        backfill_color(&mut p, has_color);
         writer.write_point(p).context("Unable to write: ")?;
     }
 
     writer.close().context("Failed to close the writer: ")?;
 
     Ok(())
+}
+
+/// Backfills a default (black) color on points missing one when the LAS point
+/// format includes color, since `las` rejects points whose color presence does
+/// not match the point format.
+fn backfill_color(point: &mut las::Point, has_color: bool) {
+    if has_color && point.color.is_none() {
+        point.color = Some(las::Color::default());
+    }
 }
 
 /// Converts the pointclouds of an E57Reader to a single LAS file.
@@ -202,10 +212,50 @@ pub fn convert_pointclouds(
         .unwrap_or_else(|e| e.into_inner())
         .clone();
 
-    for p in las_points {
+    let has_color = has_color.load(Ordering::Relaxed);
+
+    for mut p in las_points {
+        backfill_color(&mut p, has_color);
         writer.write_point(p).context("Unable to write: ")?;
     }
 
     writer.close().context("Failed to close the writer: ")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::backfill_color;
+
+    #[test]
+    fn test_backfill_color_adds_default_when_format_has_color() {
+        let mut point = las::Point::default();
+        assert!(point.color.is_none());
+
+        backfill_color(&mut point, true);
+
+        assert_eq!(point.color, Some(las::Color::default()));
+    }
+
+    #[test]
+    fn test_backfill_color_preserves_existing_color() {
+        let existing = las::Color::new(1, 2, 3);
+        let mut point = las::Point {
+            color: Some(existing),
+            ..Default::default()
+        };
+
+        backfill_color(&mut point, true);
+
+        assert_eq!(point.color, Some(existing));
+    }
+
+    #[test]
+    fn test_backfill_color_noop_when_format_has_no_color() {
+        let mut point = las::Point::default();
+
+        backfill_color(&mut point, false);
+
+        assert!(point.color.is_none());
+    }
 }


### PR DESCRIPTION
## The bug

The E57 format has a per-point `IsColorInvalid` flag. The `e57` crate's simple reader returns `color: None` for any point whose flag is set, even in a point cloud that otherwise has color. In merge mode (`convert_pointclouds`), one cloud can have color while another has none.

Both conversion paths set `has_color = true` if ANY point in the input has `point.color.is_some()`, and pass that to `get_las_writer`, which selects a LAS point format with color. But las-rs (`Writer::write_point`, las 0.9.11 `src/writer/mod.rs:345`) rejects any point where `point.color.is_some() != format.has_color` with `Error::PointAttributesDoNotMatch`.

## Failure scenario

Any input mixing colored and colorless points — a single cloud with some `IsColorInvalid` points, or merge mode combining a colored cloud with a colorless one — makes `writer.write_point(p)` fail and aborts the whole conversion, after all the E57 reading work has already been done.

## The fix

When the chosen point format has color, backfill points missing a color with `las::Color::default()` (black) at write time, in both `convert_pointcloud` and `convert_pointclouds`. The logic lives in a small private `backfill_color` helper with unit tests covering backfill, preservation of existing colors, and the no-color format case.

## Verification

- `cargo build`, `cargo clippy --all-targets` (no new diagnostics), `cargo fmt`
- `cargo test` — all tests pass, including the 3 new `backfill_color` unit tests and `test_convert_bunny`

🤖 Generated with [Claude Code](https://claude.com/claude-code)