### PR TITLE
test: stop test outputs from dirtying the repo working tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,6 +217,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "uuid",
 ]
@@ -232,6 +233,22 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -370,6 +387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +489,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +577,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ uuid = { version = "1.23.0", features = ["v4"] }
 thiserror = { version = "2.0.18" }
 
 [dev-dependencies]
+tempfile = "3.27.0"
 
 [profile.release]
 lto = true

--- a/src/convert_file.rs
+++ b/src/convert_file.rs
@@ -6,8 +6,8 @@ use anyhow::{Context, Result};
 
 use crate::convert_pointcloud::{convert_pointcloud, convert_pointclouds};
 
-use crate::stations::save_stations;
 use crate::LasVersion;
+use crate::stations::save_stations;
 
 /// Converts a given e57 file into LAS format and, optionally, as stations.
 ///
@@ -113,7 +113,12 @@ mod tests {
                 );
             }
 
-            let output_path = String::from("examples");
+            let output_dir = tempfile::tempdir().expect("Failed to create temp output dir");
+            let output_path = output_dir
+                .path()
+                .to_str()
+                .expect("Temp dir path is not valid UTF-8")
+                .to_string();
             let number_of_threads = 4;
             let as_stations = true;
             let las_version = LasVersion::new(1, 3).expect("Failed to create LAS version");
@@ -126,6 +131,22 @@ mod tests {
             );
 
             assert!(result.is_ok());
+
+            let stations_path = output_dir.path().join("stations.json");
+            assert!(
+                stations_path.is_file(),
+                "Expected stations.json to be created in the output dir"
+            );
+
+            let las_dir = output_dir.path().join("las");
+            let has_las_file = std::fs::read_dir(&las_dir)
+                .expect("Expected las directory to be created in the output dir")
+                .filter_map(|entry| entry.ok())
+                .any(|entry| entry.path().extension().is_some_and(|ext| ext == "las"));
+            assert!(
+                has_las_file,
+                "Expected at least one .las file in the las output dir"
+            );
         });
     }
 }


### PR DESCRIPTION
## Problem

`test_convert_bunny` wrote its conversion output into `examples/` inside the repo, leaving `examples/las/*.las` and `examples/stations.json` in the working tree after every `cargo test`.

## Fix

- Add `tempfile` as a dev-dependency.
- The test now writes into a `tempfile::tempdir()` (auto-cleaned when the guard drops).
- While there, the test now actually asserts its outputs: at least one `las/*.las` file and `stations.json` exist in the output dir (previously it only checked `result.is_ok()`).

## Verification

`cargo test`: 9/9 unit tests pass (including the bunny conversion); `git status` stays clean after a test run. `cargo clippy --all-targets` reports only the pre-existing `expect_used`/`panic` lints that already fire on `main` test code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)