### PR TITLE
fix: surface silent GUID fallback and silently dropped invalid points

### DIFF
--- a/src/convert_pointcloud.rs
+++ b/src/convert_pointcloud.rs
@@ -54,6 +54,7 @@ pub fn convert_pointcloud(
 
     let mut las_points: Vec<las::Point> = Vec::new();
     let mut has_color = false;
+    let mut skipped_points: usize = 0;
 
     for p in pointcloud_reader {
         let point = p.context("Could not read point: ")?;
@@ -64,7 +65,10 @@ pub fn convert_pointcloud(
 
         let las_point = match convert_point(point) {
             Some(p) => p,
-            None => continue,
+            None => {
+                skipped_points += 1;
+                continue;
+            }
         };
 
         let abs_extent = las_point
@@ -74,6 +78,10 @@ pub fn convert_pointcloud(
             .max(las_point.z.abs());
         max_cartesian = max_cartesian.max(abs_extent);
         las_points.push(las_point);
+    }
+
+    if skipped_points > 0 {
+        println!("Pointcloud {index}: skipped {skipped_points} points with invalid coordinates");
     }
 
     let path = create_path(output_path.join("las").join(format!("{}{}", index, ".las")))
@@ -147,6 +155,7 @@ pub fn convert_pointclouds(
                 .context("Unable to get point cloud iterator: ")?;
 
             let mut local_max_cartesian: f64 = 0.0;
+            let mut skipped_points: usize = 0;
             for p in pointcloud_reader {
                 let point = p.context("Could not read point: ")?;
 
@@ -156,7 +165,10 @@ pub fn convert_pointclouds(
 
                 let las_point = match convert_point(point) {
                     Some(p) => p,
-                    None => continue,
+                    None => {
+                        skipped_points += 1;
+                        continue;
+                    }
                 };
 
                 let abs_extent = las_point
@@ -169,6 +181,12 @@ pub fn convert_pointclouds(
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
                     .push(las_point);
+            }
+
+            if skipped_points > 0 {
+                println!(
+                    "Pointcloud {index}: skipped {skipped_points} points with invalid coordinates"
+                );
             }
 
             let mut guard = max_cartesian_mutex

--- a/src/get_las_writer.rs
+++ b/src/get_las_writer.rs
@@ -49,8 +49,16 @@ pub(crate) fn get_las_writer(
         y: transform,
         z: transform,
     };
-    builder.guid = Uuid::parse_str(&guid.unwrap_or(Uuid::new_v4().to_string()).replace("_", "-"))
-        .unwrap_or(Uuid::new_v4());
+    builder.guid = match guid {
+        Some(guid) => Uuid::parse_str(&guid.replace("_", "-")).unwrap_or_else(|_| {
+            let fallback = Uuid::new_v4();
+            eprintln!(
+                "Warning: could not parse E57 guid {guid:?} as a UUID, using random guid {fallback} instead"
+            );
+            fallback
+        }),
+        None => Uuid::new_v4(),
+    };
 
     let header = builder.into_header().context("Error encountered: ")?;
 


### PR DESCRIPTION
## Problems

1. **Silent, non-deterministic GUID fallback** — `get_las_writer` parsed the E57 guid and on failure silently substituted a random UUID, so the output file's guid changed on every run with no indication. The `unwrap_or(Uuid::new_v4().to_string())` also eagerly allocated a fresh UUID even when a guid was present.
2. **Silently dropped points** — both conversion paths skipped points with invalid Cartesian coordinates via a bare `continue`. A file that is 40% invalid converted "successfully" with zero signal.

## Fix

- GUID parse failure now warns on stderr with the original guid string; the underscore normalization is kept; lazy fallback via `unwrap_or_else`.
- Both `convert_pointcloud` and `convert_pointclouds` count skipped points and print a per-cloud summary when the count is > 0, matching the file's existing `println!` progress style.

## Verification

`cargo build`, `cargo test` (9/9 unit tests + bunny conversion pass), `cargo fmt` on changed files. Changes are deliberately minimal — the structural refactor of this file is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)