### PR TITLE
fix: per-axis LAS offset to stop silent precision loss on georeferenced data

### DIFF
--- a/src/convert_pointcloud.rs
+++ b/src/convert_pointcloud.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
-use crate::get_las_writer::get_las_writer;
+use crate::get_las_writer::{PointBounds, get_las_writer};
 use crate::{LasVersion, convert_point::convert_point, utils::create_path};
 
 use anyhow::{Context, Result};
@@ -50,7 +50,7 @@ pub fn convert_pointcloud(
         .pointcloud_simple(pointcloud)
         .context("Unable to get point cloud iterator: ")?;
 
-    let mut max_cartesian: f64 = 0.0;
+    let mut bounds = PointBounds::default();
 
     let mut las_points: Vec<las::Point> = Vec::new();
     let mut has_color = false;
@@ -67,12 +67,7 @@ pub fn convert_pointcloud(
             None => continue,
         };
 
-        let abs_extent = las_point
-            .x
-            .abs()
-            .max(las_point.y.abs())
-            .max(las_point.z.abs());
-        max_cartesian = max_cartesian.max(abs_extent);
+        bounds.update(&las_point);
         las_points.push(las_point);
     }
 
@@ -82,7 +77,7 @@ pub fn convert_pointcloud(
     let mut writer = get_las_writer(
         pointcloud.clone().guid,
         path,
-        max_cartesian,
+        bounds,
         has_color,
         las_version,
     )
@@ -130,7 +125,7 @@ pub fn convert_pointclouds(
     let guid = &e57_reader.guid().to_owned();
     let e57_reader_mutex = Mutex::new(e57_reader);
 
-    let max_cartesian_mutex = Mutex::new(0.0_f64);
+    let bounds_mutex = Mutex::new(PointBounds::default());
     let las_points: Vec<las::Point> = Vec::new();
     let las_points_mutex = Mutex::new(las_points);
     let has_color = Arc::new(AtomicBool::new(false));
@@ -146,7 +141,7 @@ pub fn convert_pointclouds(
                 .pointcloud_simple(pointcloud)
                 .context("Unable to get point cloud iterator: ")?;
 
-            let mut local_max_cartesian: f64 = 0.0;
+            let mut local_bounds = PointBounds::default();
             for p in pointcloud_reader {
                 let point = p.context("Could not read point: ")?;
 
@@ -159,23 +154,17 @@ pub fn convert_pointclouds(
                     None => continue,
                 };
 
-                let abs_extent = las_point
-                    .x
-                    .abs()
-                    .max(las_point.y.abs())
-                    .max(las_point.z.abs());
-                local_max_cartesian = local_max_cartesian.max(abs_extent);
+                local_bounds.update(&las_point);
                 las_points_mutex
                     .lock()
                     .unwrap_or_else(|e| e.into_inner())
                     .push(las_point);
             }
 
-            let mut guard = max_cartesian_mutex
+            bounds_mutex
                 .lock()
-                .unwrap_or_else(|e| e.into_inner());
-            let current_max_cartesian = (*guard).max(local_max_cartesian);
-            *guard = current_max_cartesian;
+                .unwrap_or_else(|e| e.into_inner())
+                .merge(&local_bounds);
 
             Ok(())
         })
@@ -184,14 +173,12 @@ pub fn convert_pointclouds(
     let path = create_path(output_path.join("las").join(format!("{}{}", 0, ".las")))
         .context("Unable to create path: ")?;
 
-    let max_cartesian = *max_cartesian_mutex
-        .lock()
-        .unwrap_or_else(|e| e.into_inner());
+    let bounds = *bounds_mutex.lock().unwrap_or_else(|e| e.into_inner());
 
     let mut writer = get_las_writer(
         Some(guid.to_owned()),
         path,
-        max_cartesian,
+        bounds,
         has_color.load(Ordering::Relaxed),
         las_version,
     )

--- a/src/get_las_writer.rs
+++ b/src/get_las_writer.rs
@@ -10,6 +10,60 @@ use crate::LasVersion;
 const MIN_SCALE: f64 = 0.001;
 const QUANTUM: f64 = 1e-4; // 0.0001 - the quantization step for scale values
 
+/// Per-axis min/max bounds of the converted LAS points.
+///
+/// Used to derive per-axis offsets (bounds midpoint) and the smallest scale
+/// that still fits the point extent in the i32 range of LAS coordinates.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PointBounds {
+    pub(crate) min: Vector<f64>,
+    pub(crate) max: Vector<f64>,
+}
+
+impl Default for PointBounds {
+    fn default() -> Self {
+        Self {
+            min: Vector {
+                x: f64::INFINITY,
+                y: f64::INFINITY,
+                z: f64::INFINITY,
+            },
+            max: Vector {
+                x: f64::NEG_INFINITY,
+                y: f64::NEG_INFINITY,
+                z: f64::NEG_INFINITY,
+            },
+        }
+    }
+}
+
+impl PointBounds {
+    /// Expands the bounds to include the given point.
+    pub(crate) fn update(&mut self, point: &las::Point) {
+        self.min.x = self.min.x.min(point.x);
+        self.min.y = self.min.y.min(point.y);
+        self.min.z = self.min.z.min(point.z);
+        self.max.x = self.max.x.max(point.x);
+        self.max.y = self.max.y.max(point.y);
+        self.max.z = self.max.z.max(point.z);
+    }
+
+    /// Expands the bounds to include another set of bounds.
+    pub(crate) fn merge(&mut self, other: &PointBounds) {
+        self.min.x = self.min.x.min(other.min.x);
+        self.min.y = self.min.y.min(other.min.y);
+        self.min.z = self.min.z.min(other.min.z);
+        self.max.x = self.max.x.max(other.max.x);
+        self.max.y = self.max.y.max(other.max.y);
+        self.max.z = self.max.z.max(other.max.z);
+    }
+
+    /// Returns true if no point was ever added to these bounds.
+    fn is_empty(&self) -> bool {
+        self.min.x > self.max.x || self.min.y > self.max.y || self.min.z > self.max.z
+    }
+}
+
 fn find_smallest_scale(x: f64) -> f64 {
     // Early return for small values that work with the minimum scale
     if x.abs() <= f64::from(i32::MAX) * MIN_SCALE {
@@ -29,25 +83,48 @@ fn find_smallest_scale(x: f64) -> f64 {
     scale.max(MIN_SCALE)
 }
 
+/// Computes the LAS transform for one axis: the offset is the bounds midpoint
+/// (rounded to whole meters for readable headers) and the scale is the
+/// smallest quantized scale such that every value on the axis fits in i32
+/// once the offset is subtracted.
+fn axis_transform(min: f64, max: f64) -> las::Transform {
+    let offset = ((min + max) / 2.0).round();
+
+    // Largest distance from the (rounded) offset; the scale must fit this.
+    let half_extent = (max - offset).abs().max((min - offset).abs());
+    let scale = find_smallest_scale(half_extent);
+
+    las::Transform { scale, offset }
+}
+
 pub(crate) fn get_las_writer(
     guid: Option<String>,
     output_path: PathBuf,
-    max_cartesian: f64,
+    bounds: PointBounds,
     has_color: bool,
     las_version: &LasVersion,
 ) -> Result<las::Writer<BufWriter<File>>> {
     let mut builder = las::Builder::from(las_version);
     builder.point_format.has_color = has_color;
     builder.generating_software = String::from("e57_to_las");
-    let offset = 0.0;
 
-    let scale = find_smallest_scale(max_cartesian);
-
-    let transform = las::Transform { scale, offset };
-    builder.transforms = Vector {
-        x: transform,
-        y: transform,
-        z: transform,
+    builder.transforms = if bounds.is_empty() {
+        // No valid points: fall back to the legacy default transform.
+        let transform = las::Transform {
+            scale: MIN_SCALE,
+            offset: 0.0,
+        };
+        Vector {
+            x: transform,
+            y: transform,
+            z: transform,
+        }
+    } else {
+        Vector {
+            x: axis_transform(bounds.min.x, bounds.max.x),
+            y: axis_transform(bounds.min.y, bounds.max.y),
+            z: axis_transform(bounds.min.z, bounds.max.z),
+        }
     };
     builder.guid = Uuid::parse_str(&guid.unwrap_or(Uuid::new_v4().to_string()).replace("_", "-"))
         .unwrap_or(Uuid::new_v4());
@@ -62,6 +139,19 @@ pub(crate) fn get_las_writer(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Checks that every value in [min, max] fits in i32 with the transform.
+    fn assert_fits(transform: &las::Transform, min: f64, max: f64) {
+        for value in [min, max] {
+            let scaled = ((value - transform.offset) / transform.scale).round();
+            assert!(
+                scaled >= f64::from(i32::MIN) && scaled <= f64::from(i32::MAX),
+                "Value {value} does not fit with scale {} and offset {}",
+                transform.scale,
+                transform.offset
+            );
+        }
+    }
 
     #[test]
     fn test_find_smallest_scale_small_values() {
@@ -140,5 +230,90 @@ mod tests {
                 "Scale {scale} should be >= theoretical min {theoretical_min} for value {value}",
             );
         }
+    }
+
+    #[test]
+    fn test_axis_transform_small_extent() {
+        // Small extents around the origin keep the minimum scale
+        let transform = axis_transform(-10.0, 10.0);
+        assert_eq!(transform.scale, MIN_SCALE);
+        assert_eq!(transform.offset, 0.0);
+        assert_fits(&transform, -10.0, 10.0);
+    }
+
+    #[test]
+    fn test_axis_transform_georeferenced_utm() {
+        // A georeferenced (UTM-like) cloud: large coordinates, small extent.
+        // With the legacy offset = 0 this required scale ~ 0.0024 (2.4 mm
+        // quantization). With the midpoint offset the minimum scale fits.
+        let (min, max) = (5_000_000.0, 5_000_100.0);
+        let transform = axis_transform(min, max);
+        assert_eq!(transform.scale, MIN_SCALE);
+        assert_eq!(transform.offset, 5_000_050.0);
+        assert_fits(&transform, min, max);
+    }
+
+    #[test]
+    fn test_axis_transform_large_extent() {
+        // Extents too large for the minimum scale still fit in i32
+        let (min, max) = (-1e10, 1e10);
+        let transform = axis_transform(min, max);
+        assert!(transform.scale > MIN_SCALE);
+        assert_fits(&transform, min, max);
+
+        // Scale stays quantized to QUANTUM steps
+        let multiplied = transform.scale * 10000.0;
+        assert!((multiplied - multiplied.round()).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_axis_transform_asymmetric_extent() {
+        // Offset rounding must not break the fit for asymmetric bounds
+        let (min, max) = (-3.5e6, 9.7e6 + 0.4321);
+        let transform = axis_transform(min, max);
+        assert_fits(&transform, min, max);
+    }
+
+    #[test]
+    fn test_point_bounds_update_and_merge() {
+        let mut bounds = PointBounds::default();
+        assert!(bounds.is_empty());
+
+        bounds.update(&las::Point {
+            x: 1.0,
+            y: -2.0,
+            z: 3.0,
+            ..Default::default()
+        });
+        bounds.update(&las::Point {
+            x: -4.0,
+            y: 5.0,
+            z: 0.5,
+            ..Default::default()
+        });
+        assert!(!bounds.is_empty());
+        assert_eq!(bounds.min.x, -4.0);
+        assert_eq!(bounds.max.x, 1.0);
+        assert_eq!(bounds.min.y, -2.0);
+        assert_eq!(bounds.max.y, 5.0);
+        assert_eq!(bounds.min.z, 0.5);
+        assert_eq!(bounds.max.z, 3.0);
+
+        let mut other = PointBounds::default();
+        other.update(&las::Point {
+            x: 10.0,
+            y: -20.0,
+            z: 30.0,
+            ..Default::default()
+        });
+        bounds.merge(&other);
+        assert_eq!(bounds.max.x, 10.0);
+        assert_eq!(bounds.min.y, -20.0);
+        assert_eq!(bounds.max.z, 30.0);
+
+        // Merging an empty bounds is a no-op
+        bounds.merge(&PointBounds::default());
+        assert_eq!(bounds.min.x, -4.0);
+        assert_eq!(bounds.max.x, 10.0);
     }
 }


### PR DESCRIPTION
## Problem

`get_las_writer` hardcoded `offset = 0.0` and grew the scale until the max absolute coordinate fit in i32. For georeferenced clouds (post-pose UTM coordinates around 5×10⁶ m are common), that forces scale ≈ 0.0024 — **2.4 mm quantization** on data scanners deliver at sub-mm precision. Silent output degradation, no crash.

## Fix

- New `PointBounds` (per-axis min/max) with `update`/`merge`, tracked by both conversion paths in place of the single max-abs fold.
- Per-axis `las::Transform`: offset = bounds midpoint (rounded to whole meters for readable headers), scale = smallest QUANTUM-quantized value fitting the half-extent from the offset, floored at the existing `MIN_SCALE` (0.001).
- Empty clouds (no valid points) keep the legacy offset 0 / min scale fallback.

The UTM regression test asserts the point of the change: coords 5,000,000–5,000,100 now get `scale = 0.001` with `offset = 5,000,050` (previously scale ≈ 0.0024 with offset 0).

## Verification

`cargo build`, `cargo fmt`, `cargo test`: 14/14 unit tests pass (5 new: axis transforms for small/UTM/large/asymmetric extents, bounds update/merge) plus the bunny end-to-end conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved point cloud export accuracy by using per-axis bounds when writing LAS files.
  * Better handles large or georeferenced coordinates, reducing the risk of overflow or precision issues during export.
  * Combined point cloud exports now share a more reliable overall range calculation, producing more consistent output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->