### PR TITLE
chore: small cleanups — stale extern crate, needless clone, misnamed helper, doc drift

### DIFF
--- a/src/convert_file.rs
+++ b/src/convert_file.rs
@@ -1,4 +1,3 @@
-extern crate rayon;
 use rayon::prelude::*;
 use std::path::Path;
 
@@ -6,8 +5,8 @@ use anyhow::{Context, Result};
 
 use crate::convert_pointcloud::{convert_pointcloud, convert_pointclouds};
 
-use crate::stations::save_stations;
 use crate::LasVersion;
+use crate::stations::save_stations;
 
 /// Converts a given e57 file into LAS format and, optionally, as stations.
 ///
@@ -58,7 +57,7 @@ pub fn convert_file(
             .par_iter()
             .enumerate()
             .try_for_each(|(index, pointcloud)| -> Result<()> {
-                println!("Saving pointcloud {}...", index);
+                println!("Saving pointcloud {index}...");
 
                 convert_pointcloud(
                     index,

--- a/src/convert_pointcloud.rs
+++ b/src/convert_pointcloud.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
 use crate::get_las_writer::get_las_writer;
-use crate::{LasVersion, convert_point::convert_point, utils::create_path};
+use crate::{LasVersion, convert_point::convert_point, utils::ensure_parent_dir};
 
 use anyhow::{Context, Result};
 use e57::{E57Reader, PointCloud};
@@ -76,11 +76,11 @@ pub fn convert_pointcloud(
         las_points.push(las_point);
     }
 
-    let path = create_path(output_path.join("las").join(format!("{}{}", index, ".las")))
+    let path = ensure_parent_dir(output_path.join("las").join(format!("{index}.las")))
         .context("Unable to create path: ")?;
 
     let mut writer = get_las_writer(
-        pointcloud.clone().guid,
+        pointcloud.guid.clone(),
         path,
         max_cartesian,
         has_color,
@@ -106,21 +106,9 @@ pub fn convert_pointcloud(
 /// - `e57_reader`: A E57Reader from a file.
 /// - `output_path`: A reference to the output dir.
 ///
-/// # Example
-/// ```ignore
-/// use std::path::Path;
-/// use e57_to_las::{convert_pointclouds, LasVersion};
-/// use anyhow::Context;
-///
-/// # fn example() -> anyhow::Result<()> {
-/// let input_path = Path::new("path/to/input.e57");
-/// let e57_reader = e57::E57Reader::from_file(input_path).context("Failed to open e57 file")?;
-/// let output_path = Path::new("path/to/output");
-/// let las_version = LasVersion::new(1, 4)?;
-/// convert_pointclouds(e57_reader, output_path, &las_version)?;
-/// # Ok(())
-/// # }
-/// ```
+/// This function is internal to the crate (it is not re-exported from the
+/// library root); use [`convert_file`](crate::convert_file) with
+/// `as_stations = false` to get the same behavior through the public API.
 pub fn convert_pointclouds(
     e57_reader: E57Reader<BufReader<File>>,
     output_path: &Path,
@@ -139,7 +127,7 @@ pub fn convert_pointclouds(
         .par_iter()
         .enumerate()
         .try_for_each(|(index, pointcloud)| -> Result<()> {
-            println!("Saving pointclouds {index}...");
+            println!("Saving pointcloud {index}...");
 
             let mut reader = e57_reader_mutex.lock().unwrap_or_else(|e| e.into_inner());
             let pointcloud_reader = reader
@@ -181,7 +169,7 @@ pub fn convert_pointclouds(
         })
         .context("Error while converting pointcloud")?;
 
-    let path = create_path(output_path.join("las").join(format!("{}{}", 0, ".las")))
+    let path = ensure_parent_dir(output_path.join("las").join("0.las"))
         .context("Unable to create path: ")?;
 
     let max_cartesian = *max_cartesian_mutex

--- a/src/las_version.rs
+++ b/src/las_version.rs
@@ -1,6 +1,8 @@
 use crate::{Error, Result};
 
 const ALLOWED_VERSIONS: [(u8, u8); 5] = [(1, 0), (1, 1), (1, 2), (1, 3), (1, 4)];
+const MIN_VERSION: (u8, u8) = ALLOWED_VERSIONS[0];
+const MAX_VERSION: (u8, u8) = ALLOWED_VERSIONS[ALLOWED_VERSIONS.len() - 1];
 
 pub struct LasVersion {
     major: u8,
@@ -12,8 +14,8 @@ impl LasVersion {
         if !ALLOWED_VERSIONS.contains(&(major, minor)) {
             return Err(Error::InvalidLasVersion(format!(
                 "must be between {} and {}",
-                format_version(ALLOWED_VERSIONS[0]),
-                format_version(ALLOWED_VERSIONS[4]),
+                format_version(MIN_VERSION),
+                format_version(MAX_VERSION),
             )));
         }
 

--- a/src/stations.rs
+++ b/src/stations.rs
@@ -1,5 +1,3 @@
-extern crate rayon;
-
 use crate::spatial_point::SpatialPoint;
 use anyhow::Result;
 use e57::PointCloud;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,18 +1,14 @@
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 
-pub(crate) fn create_path(path: PathBuf) -> Result<PathBuf> {
+pub(crate) fn ensure_parent_dir(path: PathBuf) -> Result<PathBuf> {
     let parent = path.parent().ok_or(std::io::Error::new(
         std::io::ErrorKind::Other,
         "Invalid path.",
     ))?;
 
-    std::fs::create_dir_all(&parent).context(format!(
-        "Couldn't find or create output dir {}.",
-        parent
-            .to_str()
-            .context("Invalid output dir path encoding.")?
-    ))?;
+    std::fs::create_dir_all(parent)
+        .with_context(|| format!("Couldn't find or create output dir {}.", parent.display()))?;
 
     Ok(path)
 }


### PR DESCRIPTION
Behavior-preserving cleanups from a code-quality review:

- **Stale `extern crate rayon;`** in `convert_file.rs` and `stations.rs` — pre-2018 idiom in an edition-2024 crate.
- **`pointcloud.clone().guid`** cloned the entire `PointCloud` (prototype, transform, bounds) to move one field → `pointcloud.guid.clone()`.
- **`utils::create_path` renamed to `ensure_parent_dir`** — it creates the *parent directory* and returns the path unchanged; the old name said it creates the path. Also lazy `with_context` and `Path::display()` instead of eager `format!` + `to_str()`.
- **`format!("{}{}", index, ".las")`** → `format!("{index}.las")`.
- **`ALLOWED_VERSIONS[0]` / `[4]`** hardcoded indices in the error message → named `MIN_VERSION`/`MAX_VERSION` consts derived from the array.
- **Doc drift**: the `convert_pointclouds` example showed importing it from `e57_to_las`, but it is not re-exported from the library root; the doc now points to `convert_file` for the public path.
- **Inconsistent progress strings** ("Saving pointcloud" vs "Saving pointclouds") unified.

## Verification

`cargo build`, `cargo fmt`, `cargo test` all green (9/9 unit tests + bunny end-to-end conversion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)